### PR TITLE
Fix Fahrenheit summary showing '0°F warmer than average' instead of 'about average'

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,7 +11,7 @@ from main import (
     RequestRateMonitor,
     API_ACCESS_TOKEN
 )
-from utils.temperature import calculate_historical_average, calculate_trend_slope
+from utils.temperature import calculate_historical_average, calculate_trend_slope, generate_summary
 from utils.ip_utils import get_client_ip, is_ip_whitelisted, is_ip_blacklisted
 
 # Check if rate limiting is enabled
@@ -203,6 +203,23 @@ async def test_summary_text_accuracy():
             assert f"{case['expected_diff']}°C warmer than average" in summary
         else:
             assert f"{abs(case['expected_diff'])}°C cooler than average" in summary
+
+def test_generate_summary_fahrenheit_about_average():
+    """Fahrenheit summaries should say 'about average' when the rounded diff is 0°F."""
+    current_year = datetime.now().year
+    # Historical average rounds to 49.0°F; latest is 49.2°F → diff 0.2°F → rounds to 0°F
+    data = [
+        {"x": current_year - 5, "y": 49.0},
+        {"x": current_year - 4, "y": 49.0},
+        {"x": current_year - 3, "y": 49.0},
+        {"x": current_year - 2, "y": 49.0},
+        {"x": current_year - 1, "y": 49.0},
+        {"x": current_year, "y": 49.2},
+    ]
+    summary = generate_summary(data, datetime.now(), period="daily", unit_group="fahrenheit")
+    assert "about average" in summary
+    assert "0°F warmer" not in summary
+
 
 # Rate Limiting Tests
 class TestLocationDiversityMonitor:

--- a/utils/temperature.py
+++ b/utils/temperature.py
@@ -279,7 +279,7 @@ def generate_summary(data: List[Dict[str, float]], date: datetime, period: str =
             period_context = "that period"
             period_context_alt = "that period"
 
-    if abs(diff) < 0.05:
+    if rounded_diff == 0:
         # Special case for yearly summaries to sound more natural
         if period == "yearly":
             avg_summary = f"It {tense_context_alt} an average year."


### PR DESCRIPTION
The 'about average' threshold used `abs(diff) < 0.05`, calibrated for Celsius.
In Fahrenheit mode, the same near-zero diff (e.g. 0.2°F) exceeded the threshold,
causing the summary to fall through to the 'warmer' branch and display '0°F warmer
than average'. Fix by checking `rounded_diff == 0` instead — semantically correct
for both unit systems: if the displayable number is zero, output 'about average'.

Adds a regression test covering the Fahrenheit near-zero diff case.

https://claude.ai/code/session_01DZK7VGFgMj6KVTuxxQt7em