### PR TITLE
Make local uvicorn bind host configurable via LOCAL_HOST

### DIFF
--- a/main.py
+++ b/main.py
@@ -766,5 +766,6 @@ async def admin_clear_job_queue(_admin: Annotated[bool, Depends(verify_admin_key
 if __name__ == "__main__":
     import uvicorn
 
+    host = os.getenv("LOCAL_HOST", "127.0.0.1")
     port = int(os.getenv("PORT", "8000"))
-    uvicorn.run("main:app", host="0.0.0.0", port=port)  # noqa: S104
+    uvicorn.run("main:app", host=host, port=port)


### PR DESCRIPTION
Resolves SonarQube S4830 BLOCKER on PR #79. The local-testing fallback now defaults to 127.0.0.1 and accepts an override via the LOCAL_HOST env var for ad-hoc LAN testing. Production paths (Dockerfile, Procfile) are unaffected — they invoke uvicorn from the CLI and never execute this block.