### PR TITLE
P1-133: Bump aiohttp/python-dotenv/pytest to clear 22 Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "temphist-api"
 version = "1.3.11"
 requires-python = ">=3.12"
 dependencies = [
-    "aiohttp==3.13.2",
+    "aiohttp==3.14.0",
     "anyio>=4.4.0",
     "asyncpg==0.29.0",
     "fastapi==0.120.4",
@@ -14,9 +14,9 @@ dependencies = [
     "pycountry==26.2.16",
     "pydantic==2.12.3",
     "python-dateutil==2.9.0.post0",
-    "python-dotenv==1.0.1",
-    "pytest==8.3.4",
-    "pytest-asyncio==0.25.2",
+    "python-dotenv==1.2.2",
+    "pytest==9.0.3",
+    "pytest-asyncio==1.4.0",
     "redis==7.0.1",
     "requests>=2.32.4",
     "uvicorn==0.38.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 fastapi==0.120.4
 uvicorn==0.38.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 httpx==0.28.1
 redis==7.0.1
 gunicorn==23.0.0
-aiohttp==3.13.2
+aiohttp==3.14.0
 requests>=2.32.4
 anyio>=4.4.0  # Required by httpx/starlette, fixes PVE-2024-71199
 firebase_admin==6.6.0
 pydantic==2.12.3
 python-dateutil==2.9.0.post0
-pytest==8.3.4
-pytest-asyncio==0.25.2
+pytest==9.0.3
+pytest-asyncio==1.4.0
 asyncpg==0.29.0
 matplotlib==3.11.0
 pycountry==26.2.16

--- a/tests/routers/test_shares.py
+++ b/tests/routers/test_shares.py
@@ -490,7 +490,7 @@ class TestListSharesProximityDedup:
         }
 
     def _run(self, coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return asyncio.run(coro)
 
     def _mock_store_with_rows(self, rows):
         """Return a ShareStore whose DB fetch returns the given rows."""


### PR DESCRIPTION
Closes #80.

## Summary

Bumps three pinned dependencies (plus one transitive) to clear all 22 open Dependabot alerts on this repo:

| Package          | From   | To     | Notes |
|------------------|--------|--------|-------|
| `aiohttp`        | 3.13.2 | 3.14.0 | Clears 19 alerts incl. high-severity zip bomb [GHSA-6mq8-rvhq-8wgg](https://github.com/advisories/GHSA-6mq8-rvhq-8wgg) |
| `python-dotenv`  | 1.0.1  | 1.2.2  | [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) (we only call `load_dotenv`, not the affected `set_key`) |
| `pytest`         | 8.3.4  | 9.0.3  | [GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g) — dev-only |
| `pytest-asyncio` | 0.25.2 | 1.4.0  | Required transitively — 0.25 caps `pytest<9` |

One small test fix in `tests/routers/test_shares.py`: replaced the deprecated `asyncio.get_event_loop().run_until_complete(...)` (which errors under pytest-asyncio 1.4 when no loop is current) with `asyncio.run(...)`.

## Exposure

We use `aiohttp` only as an outbound HTTP client (Visual Crossing, Open-Meteo, Mapbox, prewarmer, cache warmer). So server-side parser / multipart / static-file CVEs don't apply; the relevant defence-in-depth fixes are the cookie-leak-on-cross-origin-redirect and DNS-cache-bound issues.

## Test plan

- [x] `uv lock` resolved cleanly
- [x] `uv sync` installed the new versions
- [x] `uv run pytest` — **422 passed, 17 skipped** locally (full suite, incl. `tests/cache/test_warming_sessions.py` and weather-client tests)
- [ ] After merge: confirm all 22 Dependabot alerts auto-flip to `fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)