### PR TITLE
Bump aiohttp from 3.14.0 to 3.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv==1.2.2
 httpx==0.28.1
 redis==7.0.1
 gunicorn==23.0.0
-aiohttp==3.14.0
+aiohttp==3.14.1
 requests>=2.32.4
 anyio>=4.4.0  # Required by httpx/starlette, fixes PVE-2024-71199
 firebase_admin==6.6.0


### PR DESCRIPTION
Bumps aiohttp from 3.14.0 to 3.14.1.

Replaces #84, which conflicted because `develop` was already ahead of `main` on aiohttp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)