### PR TITLE
P1-154: Remove cramped current-year temperature label from OG image

### DIFF
--- a/routers/og_image.py
+++ b/routers/og_image.py
@@ -340,22 +340,6 @@ def _render_chart(share: dict, records: list, show_title: bool = True) -> bytes:
     trend_alpha = min(1.0, max(0.05, abs(gf)))
     ax.plot(trend_temps, years, color=_TREND_LINE, linewidth=2, alpha=trend_alpha, zorder=3, linestyle="-")
     ax.set_ylim(y_min_axis, y_max_axis)
-
-    # Annotate ref_year bar with its value
-    if ref_year in years:
-        idx = years.index(ref_year)
-        ref_temp = temps[idx]
-        ax.annotate(
-            f"{ref_temp:.0f}{unit_symbol}" if unit == "fahrenheit" else f"{ref_temp:.1f}{unit_symbol}",
-            xy=(ref_temp, ref_year),
-            xytext=(8, 0),
-            textcoords="offset points",
-            va="center",
-            color=_AVG_LINE,
-            fontsize=13,
-            fontweight="bold",
-        )
-
     ax.set_xlim(x_min, x_max)
 
     if show_title:


### PR DESCRIPTION
## Summary
- Removes the `ax.annotate(...)` call in `_render_chart()` that labeled the ref_year (current year) bar with its temperature value — it crowded the top of the chart and wasn't necessary since the bar color and axis ticks already convey the value.

Closes #100

## Test plan
- [x] Existing OG image tests pass (`pytest tests/routers/test_shares.py -k og_image`)
- [x] Manually rendered a chart via `_render_chart` with sample data and confirmed the top bar is no longer cramped with a label