### PR TITLE
Fix stale/wrong "today" weather cache TTL near UTC day boundary

### DIFF
--- a/routers/weather.py
+++ b/routers/weather.py
@@ -104,7 +104,11 @@ async def get_weather(
             year, month, day = map(int, date.split("-")[:3])
             from config import LONG_CACHE_DURATION, SHORT_CACHE_DURATION
 
-            cache_duration = SHORT_CACHE_DURATION if is_today_or_future(year, month, day) else LONG_CACHE_DURATION
+            cache_duration = (
+                SHORT_CACHE_DURATION
+                if is_today_or_future(year, month, day, location, redis_client)
+                else LONG_CACHE_DURATION
+            )
         except Exception:
             cache_duration = LONG_CACHE_DURATION
         set_cache_value(cache_key, cache_duration, json.dumps(result), redis_client)

--- a/tests/utils/test_weather.py
+++ b/tests/utils/test_weather.py
@@ -1,0 +1,44 @@
+"""Tests for utils/weather.py's is_today / is_today_or_future timezone handling."""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import cache.keys as cache_keys  # noqa: E402
+from utils.weather import is_today, is_today_or_future  # noqa: E402
+
+
+def test_is_today_without_location_uses_server_date():
+    today = date.today()
+    assert is_today(today.year, today.month, today.day) is True
+    assert is_today(1999, 1, 1) is False
+
+
+def test_is_today_or_future_without_location_uses_server_date():
+    today = date.today()
+    assert is_today_or_future(today.year, today.month, today.day) is True
+    assert is_today_or_future(9999, 12, 31) is True
+    assert is_today_or_future(1999, 1, 1) is False
+
+
+def test_is_today_uses_location_local_date_when_provided(monkeypatch):
+    # Server/UTC date differs from the location's local date near a day boundary.
+    location_local_today = date(2026, 8, 15)
+    monkeypatch.setattr(cache_keys, "get_local_today", lambda location, redis_client=None: location_local_today)
+
+    # A date that would be "yesterday" by server/UTC time is "today" for this location.
+    assert is_today(2026, 8, 15, "Auckland", None) is True
+    assert is_today(2026, 8, 14, "Auckland", None) is False
+
+
+def test_is_today_or_future_uses_location_local_date_when_provided(monkeypatch):
+    location_local_today = date(2026, 8, 15)
+    monkeypatch.setattr(cache_keys, "get_local_today", lambda location, redis_client=None: location_local_today)
+
+    assert is_today_or_future(2026, 8, 15, "Auckland", None) is True
+    assert is_today_or_future(2026, 8, 16, "Auckland", None) is True
+    assert is_today_or_future(2026, 8, 14, "Auckland", None) is False

--- a/utils/weather.py
+++ b/utils/weather.py
@@ -2,7 +2,9 @@
 
 from datetime import date as dt_date
 from datetime import timedelta
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+import redis
 
 from config import FORECAST_DAY_CACHE_DURATION_SECONDS, FORECAST_NIGHT_CACHE_DURATION_SECONDS
 
@@ -32,15 +34,38 @@ def track_missing_year(missing_years: List[Dict], year: int, reason: str):
     missing_years.append({"year": year, "reason": reason})
 
 
-def is_today(year: int, month: int, day: int) -> bool:
-    """Check if the given date is today."""
-    today = dt_date.today()
+def _resolve_reference_today(location: Optional[str], redis_client: Optional[redis.Redis]) -> dt_date:
+    """Return "today" in the location's local timezone when a location is given, else the server date."""
+    if location:
+        from cache.keys import get_local_today
+
+        return get_local_today(location, redis_client)
+    return dt_date.today()
+
+
+def is_today(
+    year: int, month: int, day: int, location: Optional[str] = None, redis_client: Optional[redis.Redis] = None
+) -> bool:
+    """Check if the given date is today.
+
+    Pass `location` (and optionally `redis_client`) so "today" is resolved in the
+    location's local timezone rather than the server's, which matters for cache TTL
+    decisions near a UTC/local day boundary.
+    """
+    today = _resolve_reference_today(location, redis_client)
     return year == today.year and month == today.month and day == today.day
 
 
-def is_today_or_future(year: int, month: int, day: int) -> bool:
-    """Check if the given date is today or in the future."""
-    today = dt_date.today()
+def is_today_or_future(
+    year: int, month: int, day: int, location: Optional[str] = None, redis_client: Optional[redis.Redis] = None
+) -> bool:
+    """Check if the given date is today or in the future.
+
+    Pass `location` (and optionally `redis_client`) so "today" is resolved in the
+    location's local timezone rather than the server's, which matters for cache TTL
+    decisions near a UTC/local day boundary.
+    """
+    today = _resolve_reference_today(location, redis_client)
     date = dt_date(year, month, day)
     return date >= today
 

--- a/utils/weather_data.py
+++ b/utils/weather_data.py
@@ -62,7 +62,7 @@ async def get_weather_for_date(
 
     try:
         year, month, day = map(int, date_str.split("-")[:3])
-        is_today_date = is_today(year, month, day)
+        is_today_date = is_today(year, month, day, location, redis_client)
     except Exception:
         is_today_date = False
 


### PR DESCRIPTION
## Summary

Investigates #106 (stale/low "today" temperature from the Open-Meteo forecast cache) and fixes one confirmed root cause found via code review.

- `is_today()` / `is_today_or_future()` in `utils/weather.py` compared the requested date to the **server's system date**, not the **location's local date**. These decide the cache TTL for a date's weather-fetch entry in `utils/weather_data.py::get_weather_for_date()` and in `routers/weather.py`'s `/weather/{location}/{date}` endpoint — `SHORT_CACHE_DURATION` (1 hour) for "today", `LONG_CACHE_DURATION` (1 **week**) for historical dates.
- Near a UTC/local-day boundary, a location whose local date has already rolled over to "today" (or hasn't yet, relative to the server) gets misclassified as historical, and its weather cache entry is written with a 1-week TTL instead of 1 hour. Since cache hits serve the stored payload without re-checking freshness, that entry then keeps serving a stale/wrong forecast mean for up to a week — matching the reported symptom (17.6°C shown while the actual forecast was up to 33°C).
- The codebase already has a correct, location-aware "today" helper — `cache.keys.get_local_today()`, which resolves each location's stored/preapproved IANA timezone — used for record-cutoff text generation in `routers/v1_records.py`. The two lower-level cache-TTL call sites just weren't wired up to it.

## Changes

- `is_today()` / `is_today_or_future()` now accept optional `location` (and `redis_client`) parameters and resolve "today" via `get_local_today()` when given, falling back to the previous server-date behavior when no location is passed.
- Both call sites (`utils/weather_data.py::get_weather_for_date`, `routers/weather.py::get_weather`) now pass `location`/`redis_client` through.
- Added `tests/utils/test_weather.py` covering both the unchanged default behavior and the new location-aware path.

## Scope note

This addresses one plausible cause identified from static code analysis (no live Railway/Redis access in this session). The issue's other hypotheses — a silently-failing cache write, or Open-Meteo's model genuinely not updating its predicted mean — still need the live Redis TTL/GET inspection and API log review described in #106 to confirm or rule out.

## Test plan

- [x] `pytest tests/` — 492 passed, 26 skipped; the only 2 failures (`test_v1_records_temporal_unit_cache.py`, Firebase auth) are pre-existing and reproduce identically on unmodified `main`/`develop`.
- [x] `ruff check` clean on all changed files; `ruff format --check` clean on all changed files (pre-existing formatting drift elsewhere in `utils/weather_data.py` is untouched by this change).
- [x] Verified no circular imports (`cache.keys` does not depend on `utils.weather`).


---
_Generated by [Claude Code](https://claude.ai/code/session_011GtafT4mjc5Bnfirke5Xf3)_